### PR TITLE
Fix typo in unfollow util error log

### DIFF
--- a/instapy/unfollow_util.py
+++ b/instapy/unfollow_util.py
@@ -1106,7 +1106,7 @@ def get_given_user_following(
 
                 except (NoSuchElementException, IndexError):
                     logger.error(
-                        "\nError occured during getting the following count "
+                        "\nError occurred during getting the following count "
                         "of '{}'\n".format(user_name)
                     )
                     return [], []


### PR DESCRIPTION
## Summary
- fix spelling for 'occurred' in unfollow_util

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for 'instapy')*

------
https://chatgpt.com/codex/tasks/task_e_6843579da92483248b468c5ed5051f16